### PR TITLE
docs: add GitHub profile overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# codextest
+# geseib
+
+Cloud engineer focusing on AWS networking, serverless applications, and automation. This profile highlights hands-on workshops, infrastructure templates, and scripting utilities.
+
+## Repository Highlights
+- **AWS networking & connectivity** – Examples and workshops such as `awsnetworking`, `tgwwalk`, and `transitgateway` explore multi-VPC designs, Transit Gateway, and routing best practices.
+- **Serverless & application prototypes** – Projects like `arcane-whispers`, `aws-acm-autovalidate`, and `aws-serverless-workshops` demonstrate Lambda, API Gateway, and event-driven patterns.
+- **Automation tools & samples** – Utilities including `r53resolverhelper`, `project1`, and `nexus-vlans` showcase Python and shell scripts for infrastructure management and testing.
+- **Engagement & event collaboration** – Repositories like `engagements`, `awselbworkshop`, and `multitgwworkshop` capture real-time collaboration for projects, teams, and organizations using React, serverless, and single-table design applications.
+
+## Notable Gists
+- `s3etag2md5hash.py` – Compare an Amazon S3 object's ETag with a local MD5 hash.
+- `byoip.sh` – Automate Bring Your Own IP setup for AWS.
+- `gistfile1.txt` – Shell script to compare service availability across AWS regions.
+- Additional snippets cover EC2 user data initialization and PHP access to AWS Secrets Manager.
+
+Find more at [github.com/geseib](https://github.com/geseib).


### PR DESCRIPTION
## Summary
- add professional profile README highlighting AWS networking, serverless, and automation work
- reference notable gists for S3 ETag hashing, BYOIP setup, and AWS region comparison scripts
- describe engagement and event repositories as real-time collaboration using React, serverless, and single-table design

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `pytest` *(collected 0 items)*

------
https://chatgpt.com/codex/tasks/task_e_6896541e7640832d8ef645e1e278eca2